### PR TITLE
Switch Enrollments stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
-# rg_instructor_analytics
+# RaccoonGang Instructor Analytics
+
+## Description
+
+This django application extends OpenEdx LMS staff functionality.
+It adds extra navigation `Instructor analytics` tab for instructors (next to `Instructor`).
+`Instructor analytics` tab includes following sections (sub-tabs):
+
+- Enrollment stats:
+
+> `enrollments`/`unenrollments` count given separately for each Course time-sliced by:
+> - arbitrary period;
+> - last week;
+> - last two weeks;
+> - last month;
+> - since course start;
+
+- Problems
+- Gradebook
+- Clusters
+- Progress Funnel
+- Suggestions
 
 ## Installation
+
 * Add `rg_instructor_analytics` and `web_fragments` to the INSTALLED_APPS (i.e. in `edx-platform/lms/envs/common.py`)
 * Add to lms url (i.e. in `edx-platform/lms/urls.py`): 
 ```python
@@ -92,7 +114,8 @@ enrollment_collector_date()
 for microsite configurations use this flag for enable/disable tab: `ENABLE_RG_INSTRUCTOR_ANALYTICS`
 
 ## Unit tests
-All tests could be run only in local. 
+All tests could be run only in local.
+
 ##### For run unit test follow the next steps:
 * Ensure that the source placed in one of the edx-platform subdirectory.
 * cd rg_instructor_analytics

--- a/rg_instructor_analytics/admin.py
+++ b/rg_instructor_analytics/admin.py
@@ -1,0 +1,12 @@
+"""
+Admin site bindings for rg_instructor_analytics app.
+"""
+
+from django.contrib import admin
+
+from rg_instructor_analytics import models
+
+admin.site.register(models.EnrollmentTabCache, admin.ModelAdmin)
+admin.site.register(models.EnrollmentByStudent, admin.ModelAdmin)
+admin.site.register(models.GradeStatistic, admin.ModelAdmin)
+admin.site.register(models.LastGradeStatUpdate, admin.ModelAdmin)

--- a/rg_instructor_analytics/models.py
+++ b/rg_instructor_analytics/models.py
@@ -3,23 +3,21 @@ Models of the rg analytics.
 """
 
 from django.contrib.auth.models import User
-from django.db.models import (
-    BooleanField, DateField, DateTimeField, FloatField, ForeignKey, IntegerField, Model, TextField
-)
+from django.db import models
 
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
-class EnrollmentTabCache(Model):
+class EnrollmentTabCache(models.Model):
     """
     Cache for the Enrollment tab.
     """
 
     course_id = CourseKeyField(max_length=255, db_index=True)
-    created = DateField(db_index=True)
-    unenroll = IntegerField(default=0)
-    enroll = IntegerField(default=0)
-    total = IntegerField(default=0)
+    created = models.DateField(db_index=True)
+    unenroll = models.IntegerField(default=0, blank=True)
+    enroll = models.IntegerField(default=0, blank=True)
+    total = models.IntegerField(default=0, blank=True)
 
     class Meta:
         """
@@ -29,15 +27,15 @@ class EnrollmentTabCache(Model):
         unique_together = ('course_id', 'created',)
 
 
-class EnrollmentByStudent(Model):
+class EnrollmentByStudent(models.Model):
     """
     Model for store last enrollment state of a user.
     """
 
     course_id = CourseKeyField(max_length=255, db_index=True)
-    student = IntegerField()
-    last_update = DateTimeField(db_index=True)
-    state = BooleanField()
+    student = models.IntegerField()
+    last_update = models.DateTimeField(db_index=True)
+    state = models.BooleanField()
 
     class Meta:
         """
@@ -47,16 +45,16 @@ class EnrollmentByStudent(Model):
         unique_together = ('course_id', 'student',)
 
 
-class GradeStatistic(Model):
+class GradeStatistic(models.Model):
     """
     Model for store grades of the student for each course.
     """
 
     course_id = CourseKeyField(max_length=255, db_index=True)
-    student = ForeignKey(User)
-    exam_info = TextField()
+    student = models.ForeignKey(User)
+    exam_info = models.TextField()
     # Represent total grade in range from 0 to 1; [0; 1]
-    total = FloatField()
+    total = models.FloatField()
 
     class Meta:
         """
@@ -67,9 +65,9 @@ class GradeStatistic(Model):
 
 
 # TODO replace this table with the Redis.
-class LastGradeStatUpdate(Model):
+class LastGradeStatUpdate(models.Model):
     """
     For the calculation diffs for the update.
     """
 
-    last_update = DateTimeField(db_index=True)
+    last_update = models.DateTimeField(db_index=True)

--- a/rg_instructor_analytics/static/rg_instructor_analytics/css/instructor_analytics.css
+++ b/rg_instructor_analytics/static/rg_instructor_analytics/css/instructor_analytics.css
@@ -851,6 +851,7 @@ body .disc-list {
 }
 .suggestion-item {
     margin-bottom: 40px;
+}
 
 .suggestion-button {
     margin: 8px 0px 8px auto;
@@ -859,4 +860,15 @@ body .disc-list {
 
 .suggestion-message {
     text-align: justify;
+}
+
+.send-email-message {
+    padding: 10px 0;
+    color: #3c3c3c;
+}
+.error-message, .validation-error-message {
+    color: red;
+}
+.success-message {
+    color: green;
 }

--- a/rg_instructor_analytics/static/rg_instructor_analytics/js/CohortTab.js
+++ b/rg_instructor_analytics/static/rg_instructor_analytics/js/CohortTab.js
@@ -8,10 +8,18 @@ function CohortTab(button, content) {
     $('#email-body').richText();
 
     content.find('#cohort-send-email-btn').click(function () {
-        // FIXME used for prevent sending email to students, during presentation
-        return;
-        let ids = '';
-        $("input:checkbox[name=cohort-checkbox]:checked").each(function () {
+
+        function isValid(data) {
+            return !!data.users_ids && !!data.subject && !!data.body
+        }
+
+        content.find('.send-email-message').addClass('hidden');
+        let $subject = content.find('#email-subject'),
+            $richTextEditor = content.find('.richText-editor'),
+            $cohortCheckbox = content.find("input:checkbox[name=cohort-checkbox]:checked"),
+            ids = '';
+
+        $cohortCheckbox.each(function () {
             if (ids.length > 0) {
                 ids += ',';
             }
@@ -20,16 +28,29 @@ function CohortTab(button, content) {
 
         let request = {
             users_ids: ids,
-            subject: $('#email-subject').val(),
-            body: $('.richText-editor').html(),
+            subject: $subject.val(),
+            body: $richTextEditor.html(),
         };
+
+        if (!isValid(request)) {
+            content.find('.send-email-message.validation-error-message').removeClass('hidden');
+            return;
+        }
 
         $.ajax({
             type: "POST",
             url: "api/cohort/send_email/",
             data: request,
-            success: () => console.log('Emails are sended'),
-            error: () => console.log('Email sending failed'),
+            success: () => {
+                content.find('.send-email-message.success-message').removeClass('hidden');
+                // clear fields
+                $subject.val('');
+                $richTextEditor.html('');
+                $cohortCheckbox.prop('checked', false)
+            },
+            error: () => {
+                content.find('.send-email-message.error-message').removeClass('hidden');
+            },
             dataType: "json"
         });
     });

--- a/rg_instructor_analytics/static/rg_instructor_analytics/js/EnrollmentTab.js
+++ b/rg_instructor_analytics/static/rg_instructor_analytics/js/EnrollmentTab.js
@@ -148,7 +148,7 @@ function EnrollmentTab(button, content) {
         }
 
         function onError() {
-            alert("Can not load statistic fo select period");
+            alert("Can't load data for selected period!");
         }
 
         $.ajax({

--- a/rg_instructor_analytics/static/rg_instructor_analytics/js/EnrollmentTab.js
+++ b/rg_instructor_analytics/static/rg_instructor_analytics/js/EnrollmentTab.js
@@ -185,44 +185,48 @@ function EnrollmentTab(button, content) {
         setPeriod(30)
     });
 
-    function setPeriod(days) {
+    enrollTab.content.find("#select-all-week").click(function () {
+        setPeriod('all')
+    });
 
-        let newFrom = new Date(toDate.datepicker('getDate') - 1000 * 60 * 60 * 24 * days);
-        if (dateStart !== "null" && newFrom < dateStart) {
-            newFrom = dateStart
+    function setPeriod(days) {
+        let newFrom;
+        if (days === 'all') {
+            newFrom = dateStart;
+        } else {
+            newFrom = new Date(dateEnd - 1000 * 60 * 60 * 24 * days);
+            if (newFrom < dateStart) {
+                newFrom = dateStart;
+            }
         }
+
         fromDate.datepicker("setDate", newFrom);
+        toDate.datepicker("setDate", dateEnd);
         updateStatPeriod();
         updateEnrolls();
     }
 
     function loadTabData() {
-        let enrollInfo = JSON.parse(periodDiv.attr('data-enroll'))[enrollTab.tabHolder.course];
-        dateStart = enrollInfo.enroll_start;
-        dateEnd = enrollInfo.enroll_end;
-
-
-        var now = new Date();
-        if (dateEnd !== "null" && (dateEnd = new Date(parseFloat(dateEnd) * 1000)) < now) {
-            toDate.datepicker("setDate", dateEnd);
-            toDate.datepicker("option", "maxDate", dateEnd);
-        } else {
-            toDate.datepicker("setDate", now);
-            toDate.datepicker("option", "maxDate", now);
-        }
-
-        if (dateStart !== "null") {
-            dateStart = new Date(parseFloat(dateStart) * 1000);
-            fromDate.datepicker("option", "minDate", dateStart);
-        }
-
-        var defaultStart = new Date();
+        let now = new Date();
+        let defaultStart = new Date();
         defaultStart.setMonth(defaultStart.getMonth() - 1);
-        fromDate.datepicker("setDate", dateStart && dateStart > defaultStart ? dateStart : defaultStart);
+
+        let enrollInfo = JSON.parse(periodDiv.attr('data-enroll'))[enrollTab.tabHolder.course];
+        dateStart = enrollInfo.enroll_start === "null" ? defaultStart : new Date(parseFloat(enrollInfo.enroll_start) * 1000);
+        dateEnd = enrollInfo.enroll_end === "null" ? now : new Date(parseFloat(enrollInfo.enroll_end) * 1000);
+
+        if (dateEnd > now) {
+            dateEnd = now;
+        }
+
+        fromDate.datepicker("option", "minDate", dateStart);
+        fromDate.datepicker("setDate", dateStart);
+        toDate.datepicker("setDate", dateEnd);
+        toDate.datepicker("option", "maxDate", dateEnd);
+
         updateStatPeriod();
         updateEnrolls()
     }
-
 
     enrollTab.loadTabData = loadTabData;
 

--- a/rg_instructor_analytics/templates/rg_instructor_analytics/cohort.html
+++ b/rg_instructor_analytics/templates/rg_instructor_analytics/cohort.html
@@ -44,6 +44,9 @@
 
     <ul id="cohort-check-list"></ul>
     <button type="button" id="cohort-send-email-btn">${_("SEND EMAIL(S)")}</button>
+    <div class="send-email-message error-message hidden">${_("Email(s) sending failed")}</div>
+    <div class="send-email-message success-message hidden">${_("Message sent")}</div>
+    <div class="send-email-message validation-error-message hidden">${_("Required fields")}</div>
 </form>
 
 

--- a/rg_instructor_analytics/templates/rg_instructor_analytics/enrollment_stats.html
+++ b/rg_instructor_analytics/templates/rg_instructor_analytics/enrollment_stats.html
@@ -31,6 +31,7 @@
     <button id="select-1-week">${_("Last Week")}</button>
     <button id="select-2-week">${_("Last 2 Weeks")}</button>
     <button id="select-4-week">${_("Last Month")}</button>
+    <button id="select-all-week">${_("Since Course Start")}</button>
 </div>
 
 <div class="enrollment-legend-holder">

--- a/rg_instructor_analytics/tests/test_view.py
+++ b/rg_instructor_analytics/tests/test_view.py
@@ -55,7 +55,7 @@ class TestEnrollmentStatisticView(TestCase):
     @patch('rg_instructor_analytics.views.has_access')
     @patch('rg_instructor_analytics.views.get_course_by_id')
     @patch('rg_instructor_analytics.views.CourseKey.from_string')
-    @patch('rg_instructor_analytics.views.EnrollmentStatisticView.get_statistic_per_day')
+    @patch('rg_instructor_analytics.views.EnrollmentStatisticView.get_daily_stats_for_course')
     def test_enroll_statistic_post_call(
         self,
         moc_get_statistic_per_day,
@@ -125,15 +125,15 @@ class TestEnrollmentStatisticView(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
-    @patch('rg_instructor_analytics.views.EnrollmentStatisticView.get_state_before')
-    @patch('rg_instructor_analytics.views.EnrollmentStatisticView.get_state_in_period')
+    @patch('rg_instructor_analytics.views.EnrollmentStatisticView.get_last_state')
+    @patch('rg_instructor_analytics.views.EnrollmentStatisticView.get_state_for_period')
     def test_get_statistic_per_day(self, mock_get_state_in_period, moc_get_state_before):
         """
         Verify collection of statistic per day.
         """
         moc_get_state_before.return_value = self.MOCK_PREVIOUS_ENROLL_STATE
         mock_get_state_in_period.return_value = self.MOCK_CURRENT_ENROLL_STATE
-        stats = EnrollmentStatisticView.get_statistic_per_day(self.MOCK_FROM_DATE, self.MOCK_TO_DATE, 'key')
+        stats = EnrollmentStatisticView.get_daily_stats_for_course(self.MOCK_FROM_DATE, self.MOCK_TO_DATE, 'key')
 
         self.assertEqual(stats, self.EXPECTED_ENROLL_STATISTIC)
 
@@ -147,19 +147,19 @@ class TestEnrollmentStatisticView(TestCase):
             {'is_active': False, 'count': 2},
         ]
         expect = (10, -2)
-        stats = EnrollmentStatisticView.get_state_before('key', '12345')
+        stats = EnrollmentStatisticView.get_last_state('key', '12345')
         self.assertEqual(stats, expect)
 
         mock_request_to_db_for_stats_before.return_value = [
             {'is_active': False, 'count': 2},
         ]
         expect = (0, -2)
-        stats = EnrollmentStatisticView.get_state_before('key', '12345')
+        stats = EnrollmentStatisticView.get_last_state('key', '12345')
         self.assertEqual(stats, expect)
 
         mock_request_to_db_for_stats_before.return_value = [
             {'is_active': True, 'count': 10},
         ]
         expect = (10, 0)
-        stats = EnrollmentStatisticView.get_state_before('key', '12345')
+        stats = EnrollmentStatisticView.get_last_state('key', '12345')
         self.assertEqual(stats, expect)

--- a/rg_instructor_analytics/utils/AccessMixin.py
+++ b/rg_instructor_analytics/utils/AccessMixin.py
@@ -54,12 +54,12 @@ class AccessMixin(object):
 
     def post(self, request, course_id):
         """
-        Overwrite base method for process post request.
+        Override base method for process post request.
         """
         return self.base_process(request, course_id)
 
     def render_to_fragment(self, request, course_id):
         """
-        Overwrite base method for process render to fragment.
+        Override base method for process render to fragment.
         """
         return self.base_process(request, course_id)


### PR DESCRIPTION
[IA-146](https://youtrack.raccoongang.com/issue/IA-146)

Data source switched for `Enrollments Stats` sub-tab:
- instead of inner `EnrollmentTabCache` model usage now use external Collector's `EnrollmentByDay` model.

Related changes: https://github.com/raccoongang/rg_instructor_analytics_log_collector/pull/3