### PR TITLE
Rework as pluggable Django app (University of Washington)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,25 +26,11 @@ It adds extra navigation `Instructor analytics` tab for instructors (next to `In
 `Instructor Analytics` must be installed together with the [Util for the tracking log parsing](https://github.com/raccoongang/rg_instructor_analytics_log_collector/tree/release-0.1.0).
  Install this utility from branch `release-0.1.0` before installing `Instructor Analytics`.
 
-* Add `rg_instructor_analytics` to the `ADDL_INSTALLED_APPS` in `lms.env.json`
-> Note: If you install `Instructor Analytics` with Open edX Ficus Release you also have to add to the `web_fragments` in `ADDL_INSTALLED_APPS`
 * Add in to the settings file `lms.env.json`
 ```
 FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT'] = True
 FEATURES['ENABLE_RG_INSTRUCTOR_ANALYTICS'] = True
 ```
-* Add to `edx-platform/lms/urls.py`:
-```python
-url(
-        r'^courses/{}/tab/instructor_analytics/'.format(
-            settings.COURSE_ID_PATTERN,
-        ),
-        include('rg_instructor_analytics.urls'),
-        name='instructor_analytics_endpoint',
-    ),
-```
-> Note: url definition must be set *before* url with the name `course_tab_view`
-
 * Apply migration
 * Ensure that celerybeat is running
 * Set setting for grade cache update, for example:

--- a/rg_instructor_analytics/__init__.py
+++ b/rg_instructor_analytics/__init__.py
@@ -1,21 +1,3 @@
 """
 rg_instructor_analytics app.
 """
-import logging
-import os
-
-from django.conf import settings
-from path import Path
-
-
-log = logging.getLogger(__name__)
-
-APP_ROOT = Path(__file__).dirname()
-ANALYTICS_TEMPLATE_DIR = os.path.join(APP_ROOT, 'templates')
-
-try:
-    settings.MAKO_TEMPLATES['main'].append(ANALYTICS_TEMPLATE_DIR)
-    log.debug('MAKO_TEMPLATES["main"]: {}'.format(settings.MAKO_TEMPLATES['main']))
-except AttributeError:
-    settings.MAKO_TEMPLATE_DIRS_BASE.append(ANALYTICS_TEMPLATE_DIR)
-    log.debug('MAKO_TEMPLATE_DIRS_BASE: {}'.format(settings.MAKO_TEMPLATE_DIRS_BASE))

--- a/rg_instructor_analytics/apps.py
+++ b/rg_instructor_analytics/apps.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+import os
+from path import Path
+
+from django.apps import AppConfig
+from openedx.core.djangoapps.plugins.constants import ProjectType, PluginURLs
+
+
+log = logging.getLogger(__name__)
+
+# assume standard here because we can't use imported from settings in class property
+COURSE_ID_PATTERN = '(?P<course_id>[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+)'
+
+
+class InstructorAnalyticsConfig(AppConfig):
+    name = 'rg_instructor_analytics'
+
+    plugin_app = {
+        PluginURLs.CONFIG: {
+            ProjectType.LMS: {
+                PluginURLs.NAMESPACE: u'rg_instructor_analytics',
+                PluginURLs.APP_NAME: u'rg_instructor_analytics',
+                PluginURLs.REGEX: r'^courses/{}/customtab/instructor_analytics/'.format(
+                    COURSE_ID_PATTERN
+                ),
+            }
+        },
+    }
+
+    def ready(self):
+        from django.conf import settings
+        from edxmako import add_lookup
+
+        # This import need for register tasks in celery
+        from .tasks import *
+
+        APP_ROOT = Path(__file__).dirname()
+        ANALYTICS_TEMPLATE_DIR = os.path.join(APP_ROOT, 'templates')
+
+        settings.MAKO_TEMPLATE_DIRS_BASE.append(ANALYTICS_TEMPLATE_DIR)
+        log.debug('MAKO_TEMPLATE_DIRS_BASE: {}'.format(settings.MAKO_TEMPLATE_DIRS_BASE))
+
+        for t in settings.TEMPLATES:
+            if t.get('NAME') == 'mako':
+                namespace = t['OPTIONS'].get('namespace', 'main')
+                add_lookup(namespace, ANALYTICS_TEMPLATE_DIR)

--- a/rg_instructor_analytics/apps.py
+++ b/rg_instructor_analytics/apps.py
@@ -20,7 +20,7 @@ class InstructorAnalyticsConfig(AppConfig):
             ProjectType.LMS: {
                 PluginURLs.NAMESPACE: u'rg_instructor_analytics',
                 PluginURLs.APP_NAME: u'rg_instructor_analytics',
-                PluginURLs.REGEX: r'^courses/{}/customtab/instructor_analytics/'.format(
+                PluginURLs.REGEX: u'courses/{}/customtab/instructor_analytics/'.format(
                     COURSE_ID_PATTERN
                 ),
             }

--- a/rg_instructor_analytics/apps.py
+++ b/rg_instructor_analytics/apps.py
@@ -5,13 +5,11 @@ import os
 from path import Path
 
 from django.apps import AppConfig
+from openedx.core.constants import COURSE_ID_PATTERN
 from openedx.core.djangoapps.plugins.constants import ProjectType, PluginURLs
 
 
 log = logging.getLogger(__name__)
-
-# assume standard here because we can't use imported from settings in class property
-COURSE_ID_PATTERN = '(?P<course_id>[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+)'
 
 
 class InstructorAnalyticsConfig(AppConfig):

--- a/rg_instructor_analytics/plugins.py
+++ b/rg_instructor_analytics/plugins.py
@@ -20,8 +20,8 @@ class InstructorAnalyticsDashboardTab(CourseTab):
     title = ugettext_noop("Instructor analytics")
     body_class = "instructor-analytics-tab"
     is_dynamic = True
-    fragment_view_name = 'rg_instructor_analytics.views.instructor_analytics_dashboard'
-    view_name = 'instructor_analytics_dashboard'
+    fragment_view_name = 'rg_instructor_analytics.views.tab_fragment.instructor_analytics_dashboard'
+    view_name = 'rg_instructor_analytics:instructor_analytics_dashboard'
 
     @classmethod
     def is_enabled(cls, course, user=None):
@@ -49,7 +49,7 @@ class InstructorAnalyticsDashboardTab(CourseTab):
         """
         Return the slug to be included in this tab's URL.
         """
-        return "tab/{}".format(self.type)
+        return "customtab/{}".format(self.type)
 
     @property
     def fragment_view(self):

--- a/rg_instructor_analytics/tests/test_view.py
+++ b/rg_instructor_analytics/tests/test_view.py
@@ -47,7 +47,7 @@ class TestEnrollmentStatisticView(TestCase):
         self.factory = RequestFactory()
 
         self.request = self.factory.post(
-            '/courses/{}/tab/instructor_analytics/api/enroll_statics/'.format(self.MOCK_COURSE_ID)
+            '/courses/{}/customtab/instructor_analytics/api/enroll_statics/'.format(self.MOCK_COURSE_ID)
         )
         self.request.user = self.MOCK_ALLOWED_USER
         self.request.POST = self.MOCK_REQUEST_PARAMS

--- a/rg_instructor_analytics/urls.py
+++ b/rg_instructor_analytics/urls.py
@@ -13,44 +13,78 @@ from rg_instructor_analytics.views.problem import (
 from rg_instructor_analytics.views.suggestion import SuggestionView
 from rg_instructor_analytics.views.tab_fragment import instructor_analytics_dashboard
 
-urlpatterns = [
+
+urlpatterns = (
+
     # Enrollment stats tab:
-    url(r'^api/enroll_statics/$', EnrollmentStatisticView.as_view(), name='enrollment_statistic_view'),
+    url(
+        r'api/enroll_statics/$',
+        EnrollmentStatisticView.as_view(),
+        name='enrollment_statistic_view'
+    ),
 
     # Problems tab:
     url(
-        r'^api/problem_statics/homework/$',
+        r'api/problem_statics/homework/$',
         ProblemHomeWorkStatisticView.as_view(),
         name='problem_homework_statistic_view'
     ),
+
     url(
-        r'^api/problem_statics/homeworksproblems/$',
+        r'api/problem_statics/homeworksproblems/$',
         ProblemsStatisticView.as_view(),
         name='problems_statistic_view'
     ),
+
     url(
-        r'^api/problem_statics/problem_detail/$',
+        r'api/problem_statics/problem_detail/$',
         ProblemDetailView.as_view(),
         name='problem_detail_view'
     ),
+
     url(
-        r'^api/problem_statics/problem_question_stat/$',
+        r'api/problem_statics/problem_question_stat/$',
         ProblemQuestionView.as_view(),
         name='problem_question_view'
     ),
 
     # Gradebook tab:
-    url(r'^api/gradebook/$', GradebookView.as_view(), name='gradebook_view'),
+    url(
+        r'api/gradebook/$',
+        GradebookView.as_view(),
+        name='gradebook_view'
+    ),
 
     # Clusters tab:
-    url(r'^api/cohort/$', CohortView.as_view(), name='cohort_view'),
-    url(r'^api/cohort/send_email/$', CohortSendMessage.as_view(), name='send_email_to_cohort'),
+    url(
+        r'api/cohort/$',
+        CohortView.as_view(),
+        name='cohort_view'
+    ),
+
+    url(
+        r'api/cohort/send_email/$',
+        CohortSendMessage.as_view(),
+        name='send_email_to_cohort'
+    ),
 
     # Progress Funnel tab:
-    url(r'^api/funnel/$', GradeFunnelView.as_view(), name='funnel'),
+    url(
+        r'api/funnel/$',
+        GradeFunnelView.as_view(),
+        name='funnel'
+    ),
 
     # Suggestions tab:
-    url(r'^api/suggestion/$', SuggestionView.as_view(), name='suggestion'),
+    url(
+        r'api/suggestion/$',
+        SuggestionView.as_view(),
+        name='suggestion'
+    ),
 
-    url(r'^$', instructor_analytics_dashboard, name='instructor_analytics_dashboard'),
-]
+    url(
+        r'$',
+        instructor_analytics_dashboard,
+        name='instructor_analytics_dashboard'
+    ),
+)

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,10 @@ setup(
         "openedx.course_tab": [
             "instructor_analytics = rg_instructor_analytics.plugins:InstructorAnalyticsDashboardTab"
         ],
+        "lms.djangoapp": [
+            "rg_instructor_analytics = rg_instructor_analytics.apps:InstructorAnalyticsConfig",
+        ],
+        "cms.djangoapp": [
+        ],
     }
 )


### PR DESCRIPTION
Use the LMS Django app plugin architecture available as of the Hawthorn release.  This application otherwise requires manual changes to urls.py which doesn't work for our installation for UW.    

I've also changed the url path to use `/customtab/` instead of `/tab/` in order to avoid problems with URL pattern precedence from standard LMS `urls.py` tab catch-all url.  Note that if edx-student-statistics is also installed this requires a change to that application to remove the catch-all `/customtab/` route.  See PR at https://github.com/raccoongang/edx-student-statistics/pull/6

